### PR TITLE
feature: call schema_rst instead of schema_json when available

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,14 +11,14 @@ Sphinx-pydantic generates schema documentation from pydantic_ models. For exampl
 
 .. code-block:: python
 
-    from pydantic import BaseModel, Schema
+    from pydantic import BaseModel, Field
 
     class Thing(BaseModel):
         """
         An example of a pydantic object from which we 
         can autogenerate schema documentation.
         """
-        name: str = Schema(
+        name: str = Field(
             ...,
             title='name',
             description='Name of this thing',
@@ -26,7 +26,7 @@ Sphinx-pydantic generates schema documentation from pydantic_ models. For exampl
 
 .. pydantic:: Thing
 
-    from pydantic import BaseModel, Schema
+    from pydantic import BaseModel, Field
 
 
     class Thing(BaseModel):
@@ -35,7 +35,7 @@ Sphinx-pydantic generates schema documentation from pydantic_ models. For exampl
         can autogenerate schema documentation.
         """
         
-        name: str = Schema(
+        name: str = Field(
             ...,
             title='name',
             description='Name of this thing',
@@ -74,7 +74,11 @@ and you can use the ``pydantic`` directive in your ``.rst`` docs.
 
     some more text ...
 
-``thing.Thing`` is a class (in the ``thing`` module) that subclasses ``pydantic.BaseModel``. Sphinx-pydantic imports this class and generates schema using pydantic's sweet API. 
+``thing.Thing`` is a class (in the ``thing`` module) that subclasses ``pydantic.BaseModel``.
+Sphinx-pydantic imports this class and generates schema using pydantic's sweet API.
+By default sphinx is calling the `schema_json` function from pydantic BaseModel.
+You can customize the displayed schema by implementing a `schema_rst` function inside your class,
+which then will be called instead without any arguments.
 
 Installation
 ------------

--- a/sphinx-pydantic/directive.py
+++ b/sphinx-pydantic/directive.py
@@ -29,8 +29,11 @@ class PyDanticSchema(JsonSchema):
         if not issubclass(obj, pydantic.BaseModel):
             raise TypeError(f"{arguments[0]} is not a subclass of pydantic.BaseModel.")
 
-        # Generate a json schema from pydantic
-        content = obj.schema_json(indent=2)
+        # Generate a json schema from pydantic. If available use user defined function schema_rst.
+        if callable(getattr(obj, "schema_rst", None)):
+            content = obj.schema_rst()
+        else:
+            content = obj.schema_json(indent=2)
 
         # Need to break content into a list to work with jsonschema.
         content = content.split('\n')


### PR DESCRIPTION
Hi, first of all thank you for this nice plugin!

In my use case I have multiple pydanitc classes reference each other. pydantic is handling things by adding a definition section in each schema with every referenced pydantic class. But often you might want to display them below each other, so you actually don't need the definition section, since this will blow up your visualization.

So the idea is that you can define a `schema_rst` function, to alter your schema instead of relying to the `schema_json` provided by pydantic.

I also updated the docs, so they are more in line with recent pydantic versions.