### PR TITLE
Set version for the requirement sphinx-jsonschema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pydantic
-sphinx-jsonschema
+sphinx-jsonschema==1.15


### PR DESCRIPTION
Using the latest version of `sphinx-jsonschema` causes:

```
Exception occurred:
  File "/Users/itay/Library/Caches/pypoetry/virtualenvs/cdm-service-mCmi3tzn-py3.8/lib/python3.8/site-packages/sphinx-pydantic/directive.py", line 23, in __init__
    super(PyDanticSchema, self).__init__(directive='jsonschema', arguments=[], options=options,
TypeError: __init__() got an unexpected keyword argument 'directive'
```